### PR TITLE
In v5.1: Correct EBI solver error messaging

### DIFF
--- a/models/CCTM/gas/ebi_cb05e51_ae6_aq/hrsolver.F
+++ b/models/CCTM/gas/ebi_cb05e51_ae6_aq/hrsolver.F
@@ -296,9 +296,13 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 !            IF( NBKUPS .LE. MXBKUPS ) THEN
             IF ( DTC .GT. DTMIN ) THEN
-! reset YC and cut sub time-step in half
+! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -308,11 +312,11 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
                DTC = 0.5D0 * DTC
 
                N_INR_STEPS = 2 ** NBKUPS
-
+               
                EXIT SUBSTEP_EBI
 
             ELSE
-
+         
                WRITE( LOGDEV, 92040 ) C, R, L
 
                WRITE( LOGDEV, 92060 )
@@ -327,18 +331,18 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
          END DO SUBSTEP_EBI
 
-         IF( LEBI_CONV )THEN
+         IF( LEBI_CONV )THEN 
              NEBI        = 1 + NEBI
 ! test for completing final EBI time-step
              IF( NEBI .GT. N_EBI_STEPS )RETURN
 ! test whether backups were done
-             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI
+             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI 
 ! Reset NBKUPS, N_INR_STEPS and sub-time step
              NBKUPS      = 0
              N_INR_STEPS = 1
              DTC         = EBI_TMSTEP
          END IF
-
+         
       END DO TSTEP_EBI
 
       RETURN
@@ -346,16 +350,17 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,

--- a/models/CCTM/gas/ebi_cb05mp51_ae6_aq/hrsolver.F
+++ b/models/CCTM/gas/ebi_cb05mp51_ae6_aq/hrsolver.F
@@ -316,9 +316,13 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 !            IF( NBKUPS .LE. MXBKUPS ) THEN
             IF ( DTC .GT. DTMIN ) THEN
-! reset YC and cut sub time-step in half
+! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -328,11 +332,11 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
                DTC = 0.5D0 * DTC
 
                N_INR_STEPS = 2 ** NBKUPS
-
+               
                EXIT SUBSTEP_EBI
 
             ELSE
-
+         
                WRITE( LOGDEV, 92040 ) C, R, L
 
                WRITE( LOGDEV, 92060 )
@@ -347,18 +351,18 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
          END DO SUBSTEP_EBI
 
-         IF( LEBI_CONV )THEN
+         IF( LEBI_CONV )THEN 
              NEBI        = 1 + NEBI
 ! test for completing final EBI time-step
              IF( NEBI .GT. N_EBI_STEPS )RETURN
 ! test whether backups were done
-             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI
+             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI 
 ! Reset NBKUPS, N_INR_STEPS and sub-time step
              NBKUPS      = 0
              N_INR_STEPS = 1
              DTC         = EBI_TMSTEP
          END IF
-
+         
       END DO TSTEP_EBI
 
       RETURN
@@ -366,16 +370,17 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,

--- a/models/CCTM/gas/ebi_saprc07tb_ae6_aq/hrsolver.F
+++ b/models/CCTM/gas/ebi_saprc07tb_ae6_aq/hrsolver.F
@@ -294,9 +294,13 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 !            IF( NBKUPS .LE. MXBKUPS ) THEN
             IF ( DTC .GT. DTMIN ) THEN
-! reset YC and cut sub time-step in half
+! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -306,11 +310,11 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
                DTC = 0.5D0 * DTC
 
                N_INR_STEPS = 2 ** NBKUPS
-
+               
                EXIT SUBSTEP_EBI
 
             ELSE
-
+         
                WRITE( LOGDEV, 92040 ) C, R, L
 
                WRITE( LOGDEV, 92060 )
@@ -325,18 +329,18 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
          END DO SUBSTEP_EBI
 
-         IF( LEBI_CONV )THEN
+         IF( LEBI_CONV )THEN 
              NEBI        = 1 + NEBI
 ! test for completing final EBI time-step
              IF( NEBI .GT. N_EBI_STEPS )RETURN
 ! test whether backups were done
-             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI
+             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI 
 ! Reset NBKUPS, N_INR_STEPS and sub-time step
              NBKUPS      = 0
              N_INR_STEPS = 1
              DTC         = EBI_TMSTEP
          END IF
-
+         
       END DO TSTEP_EBI
 
       RETURN
@@ -344,16 +348,17 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,

--- a/models/CCTM/gas/ebi_saprc07tc_ae6_aq/hrsolver.F
+++ b/models/CCTM/gas/ebi_saprc07tc_ae6_aq/hrsolver.F
@@ -287,9 +287,13 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 !            IF( NBKUPS .LE. MXBKUPS ) THEN
             IF ( DTC .GT. DTMIN ) THEN
-! reset YC and cut sub time-step in half
+! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -299,11 +303,11 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
                DTC = 0.5D0 * DTC
 
                N_INR_STEPS = 2 ** NBKUPS
-
+               
                EXIT SUBSTEP_EBI
 
             ELSE
-
+         
                WRITE( LOGDEV, 92040 ) C, R, L
 
                WRITE( LOGDEV, 92060 )
@@ -318,18 +322,18 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
          END DO SUBSTEP_EBI
 
-         IF( LEBI_CONV )THEN
+         IF( LEBI_CONV )THEN 
              NEBI        = 1 + NEBI
 ! test for completing final EBI time-step
              IF( NEBI .GT. N_EBI_STEPS )RETURN
 ! test whether backups were done
-             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI
+             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI 
 ! Reset NBKUPS, N_INR_STEPS and sub-time step
              NBKUPS      = 0
              N_INR_STEPS = 1
              DTC         = EBI_TMSTEP
          END IF
-
+         
       END DO TSTEP_EBI
 
       RETURN
@@ -337,16 +341,17 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,

--- a/models/CCTM/gas/ebi_saprc07tic_ae6i_aq/hrsolver.F
+++ b/models/CCTM/gas/ebi_saprc07tic_ae6i_aq/hrsolver.F
@@ -287,9 +287,13 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 !            IF( NBKUPS .LE. MXBKUPS ) THEN
             IF ( DTC .GT. DTMIN ) THEN
-! reset YC and cut sub time-step in half
+! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -299,11 +303,11 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
                DTC = 0.5D0 * DTC
 
                N_INR_STEPS = 2 ** NBKUPS
-
+               
                EXIT SUBSTEP_EBI
 
             ELSE
-
+         
                WRITE( LOGDEV, 92040 ) C, R, L
 
                WRITE( LOGDEV, 92060 )
@@ -318,18 +322,18 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
          END DO SUBSTEP_EBI
 
-         IF( LEBI_CONV )THEN
+         IF( LEBI_CONV )THEN 
              NEBI        = 1 + NEBI
 ! test for completing final EBI time-step
              IF( NEBI .GT. N_EBI_STEPS )RETURN
 ! test whether backups were done
-             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI
+             IF( NBKUPS .EQ. 0 )CYCLE TSTEP_EBI 
 ! Reset NBKUPS, N_INR_STEPS and sub-time step
              NBKUPS      = 0
              N_INR_STEPS = 1
              DTC         = EBI_TMSTEP
          END IF
-
+         
       END DO TSTEP_EBI
 
       RETURN
@@ -337,16 +341,17 @@ c++++++++++++++++++++++++Debug section++++++++++++++++++++++++++++++++++
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,

--- a/tools/create_ebi/runit.create_ebi
+++ b/tools/create_ebi/runit.create_ebi
@@ -1,0 +1,120 @@
+#! /bin/csh -f
+# C-shell script to run CR_EBI_SOLVER 
+
+ date; set timestamp; set echo 
+
+ set BASE            = $cwd
+ set STEM            = $BASE
+ set EXDIR           = ${BASE}/BLD  
+ set EXEC            = cr_ebi_solver 
+
+#Define compiler
+#setenv COMPILER INTEL
+#setenv COMPILER PGF90
+ setenv COMPILER GFORT
+
+#Define the gas, aerosol and aqueous components in MECHNAME
+#setenv GC_NAME       CB05MP51
+ setenv GC_NAME       SAPRC07TB
+ setenv AE_NAME       AE6
+#setenv AE_NAME       AE6I
+ setenv AQ_NAME       AQ
+
+set MECH = ` echo ${GC_NAME}_${AE_NAME}_${AQ_NAME} |  tr 'a-zA-Z' 'A-Za-z' `
+
+set REP  = ${BASE}/input/${MECH}
+
+
+#uses CMAQ version 5.1 of these include files for chemical mechanism
+ setenv RXNS_DATA_SRC  ${REP}/RXNS_DATA_MODULE.F90
+
+if ( ! ( -e ${RXNS_DATA_SRC} ) )then
+       \ls ${RXNS_DATA_SRC}
+       exit()
+ endif 
+
+
+# using templates for CMAQ version 5.0 
+ setenv TMPLDIR         ${STEM}/template_RXNSU_OPT
+ setenv DEGRADE_CODES   ${STEM}/degrade_codes_serial-RXNST
+ setenv SRCDIR          ${STEM}/src_RXNSU
+
+# output directory
+ set day = ` date "+%b-%d-%Y" `
+ setenv OUTDIR  ${BASE}/output/ebi_${MECH}-${day}
+ 
+ setenv COPYRT_FLAG      N
+ setenv CVS_HDR_FLAG     N
+
+ setenv ALL_MECHS       F    # obsolete option 
+ setenv PAR_NEG_FLAG    F    # True for CB4 and CB05 but false for SAPRC07t and RACM2 
+ setenv DEGRADE_SUBS    F    # include calls for HAPs degrade routines (true cb05tump and cb05mp51)
+# below option is a possible solution based on work by Golam Sawar if the 
+# mechanism includes excited NO2.  The user employs it at their own risk 
+# and should check the EBI solver's accuracy against the Gear or Rosenbrock solver
+ setenv NO2EX_CYCLE     F    # modify group one solution to include excited NO2
+  
+
+#Set the below compound names within the mechanism
+# Mechanism                  SAPRC99 or        CB4
+#                         # SAPRC07 / RACM2  #  CB05    #
+ setenv MECH_NO    NO     #  NO           # NO       # Mechanism name for nitric oxide
+ setenv MECH_NO2   NO2    #  NO2          # NO2      # Mechanism name for nitrogen dioxide
+ setenv MECH_NO2EX NO2EX  #  NO2EX / Not Present # NO2S     # Mechanism name for excited nitrogen dioxide
+ setenv MECH_O3    O3     #  O3           # O3       # Mechanism name for ozone
+#setenv MECH_O3P   O     #  O3P          # O        # Mechanism name for ground state oxygen atom
+ setenv MECH_O3P   O3P     #  O3P          # O        # Mechanism name for ground state oxygen atom
+ setenv MECH_O1D   O1D    #  O1D2 or O1D  # O1D      # Mechanism name for excited state oxygen atom
+ setenv MECH_OH    OH     #  HO or OH / HO  # OH       # Mechanism name for hydroxyl radical
+ setenv MECH_HO2   HO2    #  HO2          # HO2      # Mechanism name for hydroperoxy radical
+ setenv MECH_HONO  HONO   #  HONO         # HONO     # Mechanism name for nitrous acid
+#setenv MECH_HNO4  PNA   #  HNO4         # PNA      # Mechanism name for peroxynitric acid
+ setenv MECH_HNO4  HNO4   #  HNO4         # PNA      # Mechanism name for peroxynitric acid
+ setenv MECH_PAN   PAN    #  PAN          # PAN      # Mechanism name for peroxy acetyl nitrate
+#setenv MECH_C2O3  C2O3   #CCO_O2 or MECO3 / ACO3 # C2O3    # Mechanism name for peroxy acetyl radical
+ setenv MECH_C2O3  MECO3  #CCO_O2 or MECO3 # C2O3    # Mechanism name for peroxy acetyl radical
+ setenv MECH_NO3   NO3    #   NO3         # NO3      # Mechanism name for nitrate radical
+ setenv MECH_N2O5  N2O5   #   N2O5        # N2O5     # Mechanism name for dinitrogen pentoxide
+ 
+ rm cr_ebi_solver
+
+#########################################################
+ unalias rm
+
+ if( -e ./BLD ) then
+    echo "Removing old BLD directory"
+    /bin/rm -rf ./BLD
+ endif
+
+ mkdir BLD
+
+ cp makefile.v50XX  ./BLD/Makefile
+
+ cd BLD
+
+ make
+
+ cd ..
+ 
+set echo
+##########################################################
+
+ if(  -e $OUTDIR  ) then
+
+    echo "Removing old solver files"
+    /bin/rm -f ${OUTDIR}/*.[f,F]
+
+ else
+
+   mkdir -p $OUTDIR
+   \cp -f ${RXNS_DATA_SRC} $OUTDIR/.
+
+ endif
+
+ $EXDIR/$EXEC
+
+ if( $DEGRADE_SUBS  == "T" )then
+     \cp -f ${DEGRADE_CODES}/*.[f,F]  ${OUTDIR}/.
+ endif
+
+ exit() 

--- a/tools/create_ebi/src_RXNSU/module_envvar.F
+++ b/tools/create_ebi/src_RXNSU/module_envvar.F
@@ -413,11 +413,11 @@ c         LERROR = .FALSE.
 
            CALL GET_ENVIRONMENT_VARIABLE( NAME=VAR_NAME, VALUE= VAR_VALUE, STATUS=STATUS, TRIM_NAME=.TRUE.)
 
-           IF( STATUS .GT. 0 ) THEN
+           IF( STATUS .GT. 1 .OR. STATUS .LT. 0 ) THEN
               MSG = 'ERROR in environment value for ' // TRIM( VAR_NAME )
               WRITE(LOGDEV,'(a)')TRIM( MSG )
-           ELSE IF( STATUS .LT. 0 )THEN
-              STATUS  = 0
+           ELSE IF( STATUS .EQ. 1 )THEN
+              STATUS  = 1
               VAR_VALUE = TRIM( VAR_DEFAULT ) 
            END IF
            IF( STATUS .EQ. 0 )THEN
@@ -440,10 +440,10 @@ c         LERROR = .FALSE.
 
            CALL GET_ENVIRONMENT_VARIABLE( NAME=VAR_NAME, VALUE= VAR_VALUE, STATUS=STATUS, TRIM_NAME=.TRUE.)
 
-           IF( STATUS .GT. 0 ) THEN
+           IF( STATUS .GT. 1  .OR. STATUS .LT. 0 ) THEN
               MSG = 'ERROR in environment value for ' // TRIM( VAR_NAME )
               WRITE(LOGDEV,'(a)')TRIM( MSG )
-           ELSE IF( STATUS .LT. 0 )THEN
+           ELSE IF( STATUS .EQ. 1 )THEN
               STATUS  = 0
               GET_ENV_FLAG = VAR_DEFAULT
            ELSE 

--- a/tools/create_ebi/template_RXNSU_OPT/hrsolver.F
+++ b/tools/create_ebi/template_RXNSU_OPT/hrsolver.F
@@ -310,7 +310,11 @@ R5
             IF ( DTC .GT. DTMIN ) THEN
 ! reset YC and cut sub time-step in half  
                IF ( MXFL ) THEN
-                  WRITE( LOGDEV, 92010 ) C, R, L, TRIM( CHEMISTRY_SPC( S ) ), NBKUPS
+                  WRITE( LOGDEV, 92008 ) NBKUPS
+                  WRITE( LOGDEV, 92009 ) C, R, L
+                  DO S = 1, N_SPEC
+                     IF( LEBISPFL( S ) )WRITE( LOGDEV, 92010 )TRIM( CHEMISTRY_SPC( S ) )
+                  END DO 
                ELSE
                   WRITE( LOGDEV, 92000 ) C, R, L, NBKUPS
                END IF
@@ -358,16 +362,17 @@ R5
 
 92000 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'convergence failure for ' /
+     &        '         convergence failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        '  Back-up number', I2 )
+     &        '         Solution Attempt #', I2 )
 
-92010 FORMAT( 'WARNING: EBI Euler convergence failure' /
+92008 FORMAT( 'WARNING: At solution attempt #', I2  )
+92009 FORMAT( 'WARNING: EBI Euler convergence failure' /
      &        '         Reducing EBI time step because of ',
-     &         'MAXPRED convergence failure for ' /
+     &        '         MAXPRED failure in ' /
      &        '         Cell (', I3, ', ', I3, ', ', I3, ')' ,
-     &        ' and species ', A,
-     &        '  Back-up number', I2 )
+     &        '         for the below species: ')
+92010 FORMAT( A16 )
 
 92040 FORMAT( 'ERROR: Max number of EBI time step reductions exceeded'
      &      / '      Convergence failure for cell (', I3, ', ', I3,


### PR DESCRIPTION
The pull request prevents a model crash in the ebi solvers for a select set of mechanisms because how each writes a warning message. The warning occurs before reducing the time step when the solver has encountered a maximum prediction error. A segmentation error causes the crash because the CHEMISTRY_SPC array is given an index one greater than the array's size. The bad value comes from a completed DO loop that tests convergence for all chemistry species. Note that not all mechanism dependent ebi solvers require the update because their version of hrsolver.F was based on an earlier version of the create_ebi tool.

  	modified:   models/CCTM/gas/ebi_cb05e51_ae6_aq/hrsolver.F
	modified:   models/CCTM/gas/ebi_cb05mp51_ae6_aq/hrsolver.F
 	modified:   models/CCTM/gas/ebi_saprc07tb_ae6_aq/hrsolver.F
 	modified:   models/CCTM/gas/ebi_saprc07tc_ae6_aq/hrsolver.F
 	modified:   models/CCTM/gas/ebi_saprc07tic_ae6i_aq/hrsolver.F
        -changed the error messaging for MAXPRED convergence failure.
         The change removes a segmentation error that will occur because
         the CHEMISTRY_SPC is given an index one plus the array's size.
         The index error arises because its values is determined from a
         DO loop that tests for convergence

Because a tool creates an EBI solver for an updated or a new photochemical mechanism, the tool, **_create_ebi_**, has incorporated a correction based on this pull request. Note this update is also available at [https://github.com/bhutzell/CMAQ.Create_EBI_Solver/tree/version_5.1_May_27_2016] . The CMAS version tool also includes updates that add the missing run-script and modify an internal utility routine.

 	new file:   tools/create_ebi/runit.create_ebi
        -added missing run script for creation routine
 	modified:   tools/create_ebi/src_RXNSU/module_envvar.F
        -updated the routine getting environment based the STATUS argument
         returned by the GET_ENVIRONMENT_VARIABLE intrinsic function
 	modified:   tools/create_ebi/template_RXNSU_OPT/hrsolver.F
        -changed the error messaging for MAXPRED convergence failure.
         The change removes a segmentation error that will occur because
         the CHEMISTRY_SPC is given an index one plus the array's size.

@zacadelman 
@sjroselle
@jpleim
